### PR TITLE
[Added] username2 to Link

### DIFF
--- a/src/links.js
+++ b/src/links.js
@@ -31,7 +31,7 @@ class Link extends Resource {
    * @param {string} username - Username used to sign in online by the end-user.
    * @param {string} password - Password used to sign in online by the end-user.
    * @param {object} options - Optional parameters
-   *   (token, encriptionKey, usernameType, password2, accessMode, certificate, privateKey).
+   *   (token, encryptionKey, usernameType, username2, password2, accessMode, certificate, privateKey).
    * @returns {object} Newly created link.
    * @throws {RequestError}
    */
@@ -39,7 +39,7 @@ class Link extends Resource {
     institution, username, password, options = {},
   ) {
     const {
-      token, encryptionKey, usernameType, password2, accessMode,
+      token, encryptionKey, usernameType, username2, password2, accessMode,
     } = options;
     let {
       certificate, privateKey,
@@ -50,6 +50,7 @@ class Link extends Resource {
       this.#endpoint, {
         institution,
         username,
+        username2,
         password,
         password2,
         token,

--- a/src/links.js
+++ b/src/links.js
@@ -31,7 +31,8 @@ class Link extends Resource {
    * @param {string} username - Username used to sign in online by the end-user.
    * @param {string} password - Password used to sign in online by the end-user.
    * @param {object} options - Optional parameters
-   *   (token, encryptionKey, usernameType, username2, password2, accessMode, certificate, privateKey).
+   *   (token, encryptionKey, usernameType, username2, password2, accessMode, certificate,
+   *    privateKey).
    * @returns {object} Newly created link.
    * @throws {RequestError}
    */

--- a/tests/links.test.js
+++ b/tests/links.test.js
@@ -59,6 +59,7 @@ class LinksAPIMocker extends APIMocker {
           institution: 'banamex_mx_retail',
           access_mode: 'single',
           username: 'johndoe',
+          username2: 'janedoe',
           password: '123asd',
           password2: 'asd123',
           token: 'token123',
@@ -135,6 +136,7 @@ test('can register a link with options', async () => {
   const session = await newSession();
   const links = new Link(session);
   const options = {
+    username2: 'janedoe',
     password2: 'asd123',
     token: 'token123',
     encryptionKey: '123pollitoingles',


### PR DESCRIPTION
:question: What
---
Add **username2** attribute to Link 

:speech_balloon: Why
---
We need to add it to support this attribute in the public API