### PR TITLE
Adds `type` to invoices.js

### DIFF
--- a/src/invoices.js
+++ b/src/invoices.js
@@ -19,22 +19,24 @@ class Invoice extends Resource {
    * @param {string} link UUID4 representation of a link Id.
    * @param {string} dateFrom - Required date from, format is YYYY-MM-DD.
    * @param {string} dateTo - Required date to, format is YYYY-MM-DD.
+   * @param {string} type - Required type, it can be 'INFLOW' or 'OUTFLOW'.
    * @param {object} options - Optional parameters (token, encryptionKey, saveData, attachXML)
    * @returns {object} Response
    * @throws {RequestError}
    */
-  async retrieve(link, dateFrom, dateTo, options = {}) {
+  async retrieve(link, dateFrom, dateTo, type, options = {}) {
     const {
-      token, encryptionKey, saveData, attachXML,
+      token, encryptionKey, saveData, attachXML
     } = options;
     const result = await this.session.post(this.#endpoint, {
       link,
       token,
+      type,
       date_from: dateFrom,
       date_to: dateTo,
       encryption_key: encryptionKey,
       save_data: saveData,
-      attach_xml: attachXML,
+      attach_xml: attachXML
     });
     return result;
   }


### PR DESCRIPTION
Without `type` the endpoint doesn't work and returns the following error
```[ { field: 'type',
       message: 'This field is required.',
       code: 'required' } ] }