### PR TITLE
[Fixed] Balance date_to as obligatory param

### DIFF
--- a/src/balances.js
+++ b/src/balances.js
@@ -12,13 +12,14 @@ class Balance extends Resource {
    * @async
    * @param {string} link - UUID4 representation of a link Id.
    * @param {string} dateFrom - Required date from, format is YYYY-MM-DD
+   * @param {string} dateTo - Required date to, format is YYYY-MM-DD
    * @param {object} options - Optional parameters (account, dateTo, token, encryptionKey, saveData)
    * @return {object} Response
    * @throws {RequestError}
    */
-  async retrieve(link, dateFrom, options = {}) {
+  async retrieve(link, dateFrom, dateTo, options = {}) {
     const {
-      account, dateTo, token, encryptionKey, saveData,
+      account, token, encryptionKey, saveData,
     } = options;
     const result = await this.session.post(this.#endpoint, {
       link,

--- a/tests/balances.test.js
+++ b/tests/balances.test.js
@@ -50,7 +50,7 @@ class BalancesAPIMocker extends APIMocker {
 
   replyToCreateBalance() {
     this.scope
-      .post('/api/balances/', { link: linkId, date_from: '2019-10-20' })
+      .post('/api/balances/', { link: linkId, date_from: '2019-10-20', date_to: '2019-12-20' })
       .basicAuth({ user: 'secret-id', pass: 'secret-password' })
       .reply(201, balance);
   }
@@ -60,7 +60,7 @@ class BalancesAPIMocker extends APIMocker {
       .post('/api/balances/', {
         link: linkId,
         date_from: '2019-10-20',
-        date_to: '2019-12-01',
+        date_to: '2019-12-20',
         save_data: false,
         encryption_key: '123pollitoingles',
         token: 'token123',
@@ -99,7 +99,7 @@ test('can retrieve balances', async () => {
 
   const session = await newSession();
   const balances = new Balance(session);
-  const result = await balances.retrieve(linkId, '2019-10-20');
+  const result = await balances.retrieve(linkId, '2019-10-20', '2019-12-20');
 
   expect(result).toEqual(balance);
   expect(mocker.scope.isDone()).toBeTruthy();
@@ -112,12 +112,11 @@ test('can retrieve balances with options', async () => {
   const balances = new Balance(session);
   const options = {
     account: '0d3ffb69-f83b-456e-ad8e-208d0998d71d',
-    dateTo: '2019-12-01',
     token: 'token123',
     encryptionKey: '123pollitoingles',
     saveData: false,
   };
-  const result = await balances.retrieve(linkId, '2019-10-20', options);
+  const result = await balances.retrieve(linkId, '2019-10-20', '2019-12-20', options);
 
   expect(result).toEqual(balance);
   expect(mocker.scope.isDone()).toBeTruthy();


### PR DESCRIPTION
As stated in our documentation, `date_to` is required for balances endpoint.

https://docs.belvo.com/#operation/RetrieveBalances