### PR TITLE
[Added] [BEL-75] Test resume operation on incomes resource

### DIFF
--- a/tests/incomes.test.js
+++ b/tests/incomes.test.js
@@ -45,6 +45,12 @@ class IncomesAPIMocker extends APIMocker {
       .reply(200, incomesResp);
   }
 
+  replyToResumeSession() {
+    this.scope
+      .patch('/api/incomes/', { session: 'abc123', token: 'my-token', link: linkId })
+      .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+      .reply(200, incomesResp);
+  }
 }
 
 const mocker = new IncomesAPIMocker('https://fake.api');
@@ -74,6 +80,17 @@ test('can retrieve incomes with options', async () => {
     saveData: false,
   };
   const result = await incomes.retrieve(linkId, options);
+
+  expect(result).toEqual(incomesResp);
+  expect(mocker.scope.isDone()).toBeTruthy();
+});
+
+test('can resume incomes session', async () => {
+  mocker.login().replyToResumeSession();
+
+  const session = await newSession();
+  const incomes = new Income(session);
+  const result = await incomes.resume('abc123', 'my-token', linkId);
 
   expect(result).toEqual(incomesResp);
   expect(mocker.scope.isDone()).toBeTruthy();


### PR DESCRIPTION
We want the `/income` endpoint to be able to receive `PATCH` requests via this client. This was implicitly supported, so simply a test case has been added.