### PR TITLE
[Added] [BEL-1912] Widget branding in the access_token

### DIFF
--- a/src/widgetToken.js
+++ b/src/widgetToken.js
@@ -18,6 +18,7 @@ class WidgetToken extends Resource {
   async create(options = {}) {
     let { scopes } = options;
     const { link } = options;
+    const { widget } = options;
     scopes = scopes || 'read_institutions,write_links,read_links';
     const result = await this.session.post(
       this.#endpoint, {
@@ -25,6 +26,7 @@ class WidgetToken extends Resource {
         password: this.session.keyPassword,
         link_id: link,
         scopes,
+        widget,
       },
     );
     return result;

--- a/tests/widgetToken.test.js
+++ b/tests/widgetToken.test.js
@@ -38,7 +38,24 @@ class TokenAPIMocker extends APIMocker {
       .reply(200, token);
     return this;
   }
+
+  replyWithATokenWithWidgetBranding() {
+    this.scope
+      .post('/api/token/', {
+        id: 'secret-id',
+        password: 'secret-password',
+        scopes: 'read_institutions',
+        widget: {
+          branding: {
+            test: "test"
+          }
+        }
+      })
+      .reply(200, token);
+    return this;
+  }
 }
+
 
 const mocker = new TokenAPIMocker('https://fake.api');
 
@@ -73,6 +90,22 @@ test('can get a token with specific scopes', async () => {
   const session = await newSession();
   const widgetTokenResource = new WidgetToken(session);
   const options = {scopes: 'read_institutions'};
+  const result = await widgetTokenResource.create(options);
+
+  expect(result).toEqual(token);
+});
+
+test('can get a token with widget branding', async () => {
+  mocker.login().replyWithATokenWithWidgetBranding();
+
+  const session = await newSession();
+  const widgetTokenResource = new WidgetToken(session);
+  const widgetBranding = {
+    branding: {
+      test: 'test'
+    }
+  }
+  const options = {scopes: 'read_institutions', widget: widgetBranding};
   const result = await widgetTokenResource.create(options);
 
   expect(result).toEqual(token);


### PR DESCRIPTION
:question: What
---
<!-- Let us know what did you change in the code -->
Add the support for the new widget field in our WidgetToken creation

:speech_balloon: Why
---
<!-- Are there any arguments that will help to understand these changes? Okay, put'em here... -->

<!-- If this PR Relates or Fixes an issue, please also add it --> 
Because in the public API we have added a new field when we create a WidgetToken and we need to support it
[1723]( https://belvoteam.atlassian.net/browse/BEL-1723)