### PR TITLE
[Added][BEL-1544] Limit param was removed in favor to pass object param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "belvo",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belvo",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "The node.js module for the Belvo API",
   "main": "lib/belvo.js",
   "scripts": {

--- a/src/http.js
+++ b/src/http.js
@@ -54,7 +54,6 @@ class APISession {
       password: secretKeyPassword,
     };
 
-
     try {
       await raiseForStatus(this.session.get('/api/', { auth }));
     } catch (error) {
@@ -71,10 +70,11 @@ class APISession {
    * Get all results from a paginated response
    * @async
    * @param {string} url - API endpoint
+   * @param {object} params - Params to filter results in get.
    * @yields {object} The next result in the response.
    */
-  async* getAll(url) {
-    const { data: { results, next } } = await this.session.get(url);
+  async* getAll(url, params = {}) {
+    const { data: { results, next } } = await this.session.get(url, { params });
 
     // eslint-disable-next-line no-restricted-syntax
     for (const item of results) {
@@ -91,11 +91,12 @@ class APISession {
    * @async
    * @param {string} url - API endpoint
    * @param {number} limit - Maximum number of results to get.
+   * @param {object} params - Params to filter results in get.
    * @returns {array} List of resources.
    */
-  async list(url, limit = 100) {
+  async list(url, limit = 100, params = {}) {
     const results = [];
-    const generator = await this.getAll(url);
+    const generator = await this.getAll(url, params);
     for (let index = 0; index < limit; index += 1) {
       // eslint-disable-next-line no-await-in-loop
       const next = await generator.next();

--- a/src/resources.js
+++ b/src/resources.js
@@ -13,12 +13,14 @@ class Resource {
   /**
    * Get a list of resources.
    * @async
-   * @param {number} limit - Maximum number of results.
+   * @param {Object} params - Receives two parameters.
+   * @param {number} [params.limit=100] - Maximum number of results.
+   * @param {Object} [params.filters={}] - Filters to get custom results.
    * @returns {array} List of results.
    * @throws {RequestError}
    */
-  async list(limit = 100) {
-    const result = await this.session.list(this.#endpoint, limit);
+  async list({ limit = 100, filters = {} } = {}) {
+    const result = await this.session.list(this.#endpoint, limit, filters);
     return result;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 import { readFileSync, existsSync } from 'fs';
 
-
 const encodeFileB64 = (path) => {
   if (path && existsSync(path)) {
     return readFileSync(path).toString('BASE64');

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -243,3 +243,25 @@ test('delete returns false when not ok', async () => {
   expect(result).toBeFalsy();
   expect(mocker.scope.isDone()).toBeTruthy();
 });
+
+test('get results by filters', async () => {
+  mocker.login();
+
+  const scopeUnused = nock('https://fake.api')
+    .get('/api/things/')
+    .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+    .query({ foo: 'bar' })
+    .reply(200, {
+      count: 3,
+      next: 'https://fake.api/api/things/?foo=bar&page=2',
+      previous: 'https://fake.api/api/things/?foo=bar&page=1',
+      results: [{ one: 1}, { two: 2 }]
+    });
+
+  const session = await newSession();
+  const result = await session.list('/api/things/', 2, { foo: 'bar' });
+
+  expect(result).toEqual([{ one: 1 }, { two: 2 }]);
+  expect(scopeUnused.isDone()).toBeTruthy();
+  expect(mocker.scope.isDone()).toBeTruthy();
+});


### PR DESCRIPTION
# Why

- Currently is not possible get data using filter options in node-sdk using `list` function.
- Receiving an Object is more flexible and scalable

# What?
- Allow customers get only data he wants sending parameter options to filter