### PR TITLE
[Changed] bump next valid version after unpublish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "belvo",
-  "version": "0.14.1",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "belvo",
-      "version": "0.14.1",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belvo",
-  "version": "0.14.1",
+  "version": "0.16.0",
   "description": "The node.js module for the Belvo API",
   "main": "lib/belvo.js",
   "scripts": {


### PR DESCRIPTION
Round 3, not jump to v0.16.0, before that try with a `patch` version to jump v0.15.1

## Why? 
https://www.npmjs.com/policies/unpublish