### PR TITLE
[Added] [BEL-2780] Add links patch method for access_mode

### DIFF
--- a/src/links.js
+++ b/src/links.js
@@ -111,6 +111,30 @@ class Link extends Resource {
   async token(id, scopes) {
     return this.session.post('api/token/', { link_id: id, scopes });
   }
+
+  /**
+   * Patch an existing link.
+   * @async
+   * @param {string} id - UUID4 representation of the link Id.
+   * @param {object} options - Optional parameters
+   *   (accessMode).
+   * @returns {object} Link data updated.
+   * @throws {RequestError}
+   */
+  async patch(
+    id, options = {},
+  ) {
+    const {
+      accessMode,
+    } = options;
+
+    const result = await this.session.patch(
+      `${this.#endpoint}${id}/`, {
+        access_mode: accessMode,
+      },
+    );
+    return result;
+  }
 }
 
 export default Link;

--- a/tests/links.test.js
+++ b/tests/links.test.js
@@ -52,6 +52,18 @@ class LinksAPIMocker extends APIMocker {
       .reply(201, singleLink);
   }
 
+  replyToUpdateAccessMode() {
+    this.scope
+      .patch(
+        `/api/links/${singleLink.id}/`,
+        {
+          access_mode: 'single',
+        },
+      )
+      .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+      .reply(200, singleLink);
+  }
+
   replyToCreateRecurrentLinkWithOptions() {
     this.scope
       .post(
@@ -249,5 +261,16 @@ test('can list link given filter external_id', async () => {
   const results = await links.list({ filters });
 
   expect(results).toEqual([singleLink]);
+  expect(mocker.scope.isDone()).toBeTruthy();
+});
+
+test('can patch link access_mode', async () => {
+  mocker.login().replyToUpdateAccessMode();
+
+  const session = await newSession();
+  const links = new Link(session);
+  const result = await links.patch(singleLink.id, { accessMode: Link.SINGLE });
+
+  expect(result).toEqual(singleLink);
   expect(mocker.scope.isDone()).toBeTruthy();
 });


### PR DESCRIPTION
:question: What
---
- Add `PATCH` method on links resource to update `access_mode`


:speech_balloon: Why
---
- We added in our `public_api` and we need to support it in all SDKs

Part of [BEL-2780](https://belvoteam.atlassian.net/browse/BEL-2780)
