### PR TITLE
[Added] [BEL-3519] Support dates for tax_returns

### DIFF
--- a/src/taxReturns.js
+++ b/src/taxReturns.js
@@ -9,29 +9,50 @@ class TaxReturn extends Resource {
   #endpoint = 'api/tax-returns/'
 
   /**
+   * @constant {string}
+   * @static
+   * */
+  static YEARLY = 'yearly';
+
+  /**
+   * @constant {string}
+   * @static
+   */
+  static MONTHLY = 'monthly';
+
+  /**
    * Retrieve tax returns information from a specific fiscal link.
    *
    * @async
    * @param {string} link - UUID4 representation of a link Id.
-   * @param {string} yearFrom - Required year from, format is YYYY-MM-DD
-   * @param {string} yearTo - Required year to, format is YYYY-MM-DD.
+   * @param {string} yearDateFrom - Required year or date from, format is YYYY-MM-DD
+   * @param {string} yearDateTo - Required year or date to, format is YYYY-MM-DD.
    * @param {object} options - Optional parameters (token, encryptionKey, saveData, attachPDF)
    * @returns {object} Response
    * @throws {RequestError}
    */
-  async retrieve(link, yearFrom, yearTo, options = {}) {
+  async retrieve(link, yearDateFrom, yearDateTo, options = {}) {
     const {
-      token, encryptionKey, saveData, attachPDF,
+      token, encryptionKey, saveData, attachPDF, type,
     } = options;
-    const result = await this.session.post(this.#endpoint, {
+
+    const data = {
       link,
       token,
-      year_from: yearFrom,
-      year_to: yearTo,
       encryption_key: encryptionKey,
       save_data: saveData,
       attach_pdf: attachPDF,
-    });
+      type,
+    };
+
+    if (type === TaxReturn.MONTHLY) {
+      data.date_from = yearDateFrom;
+      data.date_to = yearDateTo;
+    } else {
+      data.year_from = yearDateFrom;
+      data.year_to = yearDateTo;
+    }
+    const result = await this.session.post(this.#endpoint, data);
     return result;
   }
 }

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -2,6 +2,7 @@ import nock from 'nock';
 import { APIMocker, newSession } from './fixtures';
 import APISession from '../src/http';
 import RequestError from '../src/exceptions';
+import Client from '../src/belvo';
 
 
 class Mocker extends APIMocker {
@@ -104,6 +105,17 @@ test('incorrect login returns false', async () => {
   const login = await badSession.login('secret-id', 'wrong-password');
 
   expect(login).toBeFalsy();
+});
+
+test('belvo client throws an error', async () => {
+  const client = new Client('secret-id', 'secret-password', 'https://fake.api');
+  let error;
+  try {
+      await client.connect()
+  } catch (e) {
+      error = e;
+  }
+  expect(error).toEqual(new Error("Login failed."))
 });
 
 test('getAll() supports pagination', async () => {

--- a/tests/links.test.js
+++ b/tests/links.test.js
@@ -87,6 +87,29 @@ class LinksAPIMocker extends APIMocker {
       .reply(201, recurrentLink);
   }
 
+  replyToCreateRecurrentLinkWithEmptyCertificate() {
+    this.scope
+      .post(
+        '/api/links/',
+        {
+          institution: 'banamex_mx_retail',
+          username: 'johndoe',
+          username2: 'janedoe',
+          username3: 'foo',
+          password: '123asd',
+          password2: 'asd123',
+          token: 'token123',
+          encryption_key: '123pollitoingles',
+          username_type: '02',
+          certificate: null,
+          private_key: null,
+          external_id: 'abc',
+        },
+      )
+      .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+      .reply(201, recurrentLink);
+  }
+
   replyToCreateRecurrentLink() {
     this.scope
       .post(
@@ -272,5 +295,28 @@ test('can patch link access_mode', async () => {
   const result = await links.patch(singleLink.id, { accessMode: Link.SINGLE });
 
   expect(result).toEqual(singleLink);
+  expect(mocker.scope.isDone()).toBeTruthy();
+});
+
+test('cant register a link with options and empty certificate ', async () => {
+  mocker.login().replyToCreateRecurrentLinkWithEmptyCertificate();
+
+  const session = await newSession();
+  const links = new Link(session);
+
+  const options = {
+    username2: 'janedoe',
+    username3: 'foo',
+    password2: 'asd123',
+    token: 'token123',
+    encryptionKey: '123pollitoingles',
+    usernameType: '02',
+    certificate: `${__dirname}/dont_exist.txt`,
+    privateKey: `${__dirname}/dont_exist.txt`,
+    externalId: 'abc',
+  };
+
+  const result = await links.register('banamex_mx_retail', 'johndoe', '123asd', options);
+  expect(result).toEqual(recurrentLink);
   expect(mocker.scope.isDone()).toBeTruthy();
 });

--- a/tests/taxReturns.test.js
+++ b/tests/taxReturns.test.js
@@ -447,6 +447,21 @@ class TaxReturnsAPIMocker extends APIMocker {
       .reply(201, taxReturn);
   }
 
+  replyToCreateTaxReturnWithType() {
+    this.scope
+      .post('/api/tax-returns/', { link: linkId, type: "yearly", year_from: 2019, year_to: 2020 })
+      .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+      .reply(201, taxReturn);
+  }
+
+  replyToCreateTaxReturnWithDates() {
+    this.scope
+      .post('/api/tax-returns/', { link: linkId, type: 'monthly', date_from: '2020-01-01', date_to: '2020-03-30'})
+      .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+      .reply(201, taxReturn);
+  }
+
+
   replyToCreateTaxReturnWithOptions() {
     this.scope
       .post('/api/tax-returns/', {
@@ -457,6 +472,22 @@ class TaxReturnsAPIMocker extends APIMocker {
         encryption_key: '123pollitoingles',
         token: 'token123',
         attach_pdf: false,
+      })
+      .basicAuth({ user: 'secret-id', pass: 'secret-password' })
+      .reply(201, taxReturn);
+  }
+
+  replyToCreateTaxReturnWithDateOptions() {
+    this.scope
+      .post('/api/tax-returns/', {
+        link: linkId,
+        date_from: "2020-01-01",
+        date_to: "2020-01-30",
+        save_data: false,
+        encryption_key: '123pollitoingles',
+        token: 'token123',
+        attach_pdf: false,
+        type: "monthly",
       })
       .basicAuth({ user: 'secret-id', pass: 'secret-password' })
       .reply(201, taxReturn);
@@ -497,6 +528,29 @@ test('can retrieve tax returns', async () => {
   expect(mocker.scope.isDone()).toBeTruthy();
 });
 
+test('can retrieve tax returns with type', async () => {
+  mocker.login().replyToCreateTaxReturnWithType();
+
+  const session = await newSession();
+  const taxReturns = new TaxReturn(session);
+  const result = await taxReturns.retrieve(linkId, 2019, 2020, {type:"yearly"});
+
+  expect(result).toEqual(taxReturn);
+  expect(mocker.scope.isDone()).toBeTruthy();
+});
+
+
+test('can retrieve tax returns with dates', async () => {
+  mocker.login().replyToCreateTaxReturnWithDates();
+
+  const session = await newSession();
+  const taxReturns = new TaxReturn(session);
+  const result = await taxReturns.retrieve(linkId, '2020-01-01', '2020-03-30', {type: 'monthly'});
+
+  expect(result).toEqual(taxReturn);
+  expect(mocker.scope.isDone()).toBeTruthy();
+});
+
 test('can retrieve tax returns with options', async () => {
   mocker.login().replyToCreateTaxReturnWithOptions();
 
@@ -509,6 +563,24 @@ test('can retrieve tax returns with options', async () => {
     attachPDF: false,
   };
   const result = await taxReturns.retrieve(linkId, 2019, 2020, options);
+
+  expect(result).toEqual(taxReturn);
+  expect(mocker.scope.isDone()).toBeTruthy();
+});
+
+test('can retrieve tax returns  with dates and options', async () => {
+  mocker.login().replyToCreateTaxReturnWithDateOptions();
+
+  const session = await newSession();
+  const taxReturns = new TaxReturn(session);
+  const options = {
+    token: 'token123',
+    encryptionKey: '123pollitoingles',
+    saveData: false,
+    attachPDF: false,
+    type: "monthly",
+  };
+  const result = await taxReturns.retrieve(linkId, "2020-01-01", "2020-01-30", options);
 
   expect(result).toEqual(taxReturn);
   expect(mocker.scope.isDone()).toBeTruthy();


### PR DESCRIPTION
:question: What
---
<!-- Let us know what did you change in the code -->
Added the support for dates parameter in the tax_returns

:speech_balloon: Why
---
<!-- Are there any arguments that will help to understand these changes? Okay, put'em here... -->

<!-- If this PR Relates or Fixes an issue, please also add it --> 
to be updated with our endpoint