### PR TITLE
[Changed] [BEL-0000] Bump version to 0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "belvo",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "belvo",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belvo",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "The node.js module for the Belvo API",
   "main": "lib/belvo.js",
   "scripts": {


### PR DESCRIPTION
The previous release was not released because of the Travis error build 
`400 Bad Request - PUT https://registry.npmjs.org/belvo - Cannot publish over previously published version "0.15.0".`
This happens because we were unpublished the version` 15.0` but the **NPM** keeps that version anyway 

To be able to release the changes needed to go with 0.15.1