### PR TITLE
[Added] [BEL-3906] Javascript - was added support to get base url given an environment name

### DIFF
--- a/src/belvo.js
+++ b/src/belvo.js
@@ -12,10 +12,17 @@ import TaxReturn from './taxReturns';
 import TaxStatus from './taxStatus';
 import Transaction from './transactions';
 import WidgetToken from './widgetToken';
+import { urlResolver } from './utils';
 
 class Client {
   constructor(secretKeyId, secretKeyPassword, url = null) {
-    this.session = new APISession(url);
+    const belvoUrl = urlResolver(url || process.env.BELVO_API_URL);
+
+    if (!belvoUrl) {
+      throw new Error('You need to provide a URL or a valid environment.');
+    }
+
+    this.session = new APISession(belvoUrl);
     this.secretKeyId = secretKeyId;
     this.secretKeyPassword = secretKeyPassword;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,5 +7,18 @@ const encodeFileB64 = (path) => {
   return null;
 };
 
+const Environment = Object.freeze({
+  SANDBOX: 'https://sandbox.belvo.com',
+  DEVELOPMENT: 'https://development.belvo.com',
+  PRODUCTION: 'https://api.belvo.com',
+});
+
+const urlResolver = (environment = '') => {
+  if (environment) {
+    return Environment[environment.toUpperCase()] || environment;
+  }
+  return null;
+};
+
 // eslint-disable-next-line import/prefer-default-export
-export { encodeFileB64 };
+export { encodeFileB64, urlResolver };


### PR DESCRIPTION
:question: What
---
<!-- Let us know what did you change in the code -->
- It's possible pass an environment name to `Client` to get api url

`client = new Client('secret-id', 'secret-password', 'sandbox|production|development')`

:speech_balloon: Why
---
<!-- Are there any arguments that will help to understand these changes? Okay, put'em here... -->
- It's easier and friendly pass an environment name avoiding an extra path for base url

<!-- If this PR Relates or Fixes an issue, please also add it --> 
https://belvoteam.atlassian.net/browse/BEL-3906